### PR TITLE
add naming to geoms

### DIFF
--- a/lenspyx/remapping/utils_geom.py
+++ b/lenspyx/remapping/utils_geom.py
@@ -31,6 +31,7 @@ class Geom:
                     nphi: number of pixels in each ring
                     ringstart: index of first pixel of each ring in real space map
                     w: quadrature weight for each ring (used for SHT of 'analysis'-type )
+                    name: identifier for the geometry, used for e.g. debugging
 
 
         """


### PR DESCRIPTION
### New optional parameter for geometries

**name**: an identifier to e.g. quickly check which geometry was initialized. standard geometries now have their name set to 'gl', 'tgl', 'healpix', etc.